### PR TITLE
TCP stack changes for beacon propagation

### DIFF
--- a/src/core/tcp_in.c
+++ b/src/core/tcp_in.c
@@ -208,6 +208,13 @@ tcp_input(struct pbuf *p, struct netif *inp)
         /* Found. Setting port and IP of anycast's instance. */
         pcb->remote_port = tcphdr->src;
         scion_addr_set(&(pcb->remote_ip), &current_iphdr_src);
+        /* If this is SYN+ACK to BS, then copy path */
+        if (pcb->svc == SVC_BEACON){
+            if (pcb->path->len == current_path.len)
+                memcpy(pcb->path->raw_path, current_path.raw_path, current_path.len);
+            else
+                LWIP_DEBUGF(TCP_INPUT_DEBUG, ("SYN+ACK to BS has path with different length\n"));
+        }
 
         LWIP_ASSERT("tcp_input: pcb->next != pcb (before cache)", pcb->next != pcb);
         if (prev != NULL) {


### PR DESCRIPTION
- prepend one_hop_path extension to `SYN` packets to `BS`.
- copy path of `SYN+ACK` packet (path used for sending `SYN` has only first HOF valid)

One issue is that prepending an extension by stack can violate max number of hop-by-hop extensions. In that case app would ideally receive SCMP error, which sounds better to me than silently dropping some extension(s).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-lwip/6)

<!-- Reviewable:end -->
