### PR TITLE
Handle one-hop-path extension in TCP.

### DIFF
--- a/src/core/tcp_in.c
+++ b/src/core/tcp_in.c
@@ -208,6 +208,14 @@ tcp_input(struct pbuf *p, struct netif *inp)
         /* Found. Setting port and IP of anycast's instance. */
         pcb->remote_port = tcphdr->src;
         scion_addr_set(&(pcb->remote_ip), &current_iphdr_src);
+        if (pcb->scion_flags & SCION_ONEHOPPATH) {
+            /* Clear the flag, isn't needed any more */
+            pcb->scion_flags &= ~SCION_ONEHOPPATH;
+            if (pcb->path->len == current_path.len)
+                memcpy(pcb->path->raw_path, current_path.raw_path, current_path.len);
+            else
+                LWIP_DEBUGF(TCP_INPUT_DEBUG, ("SYN+ACK to BS has path with different length\n"));
+        }
 
         LWIP_ASSERT("tcp_input: pcb->next != pcb (before cache)", pcb->next != pcb);
         if (prev != NULL) {

--- a/src/core/tcp_out.c
+++ b/src/core/tcp_out.c
@@ -876,7 +876,7 @@ tcp_send_empty_ack(struct tcp_pcb *pcb)
         IP_PROTO_TCP, p->tot_len);
 #endif
 #ifdef SCION
-  scion_output(p, &(pcb->local_ip), &(pcb->remote_ip), pcb->path, pcb->exts, IP_PROTO_TCP);
+  scion_output(p, &(pcb->local_ip), &(pcb->remote_ip), pcb->path, pcb->exts, IP_PROTO_TCP, 0);
 #elif LWIP_NETIF_HWADDRHINT
   ip_output_hinted(p, &(pcb->local_ip), &(pcb->remote_ip), pcb->ttl, pcb->tos,
       IP_PROTO_TCP, &(pcb->addr_hint));
@@ -1165,7 +1165,7 @@ tcp_output_segment(struct tcp_seg *seg, struct tcp_pcb *pcb)
   TCP_STATS_INC(tcp.xmit);
 
 #ifdef SCION
-  scion_output(seg->p, &(pcb->local_ip), &(pcb->remote_ip), pcb->path, pcb->exts, IP_PROTO_TCP);
+  scion_output(seg->p, &(pcb->local_ip), &(pcb->remote_ip), pcb->path, pcb->exts, IP_PROTO_TCP, pcb->scion_flags);
 #elif LWIP_NETIF_HWADDRHINT
   ip_output_hinted(seg->p, &(pcb->local_ip), &(pcb->remote_ip), pcb->ttl, pcb->tos,
       IP_PROTO_TCP, &(pcb->addr_hint));
@@ -1232,7 +1232,7 @@ tcp_rst(u32_t seqno, u32_t ackno,
   snmp_inc_tcpoutrsts();
    /* Send output with hardcoded TTL since we have no access to the pcb */
 #ifdef SCION
-  scion_output(p, local_ip, remote_ip, path, exts, IP_PROTO_TCP);
+  scion_output(p, local_ip, remote_ip, path, exts, IP_PROTO_TCP, 0);
 #else
   ip_output(p, local_ip, remote_ip, TCP_TTL, 0, IP_PROTO_TCP);
 #endif
@@ -1407,7 +1407,7 @@ tcp_keepalive(struct tcp_pcb *pcb)
 
   /* Send output to IP */
 #ifdef SCION
-  scion_output(p, &(pcb->local_ip), &(pcb->remote_ip), pcb->path, pcb->exts, IP_PROTO_TCP);
+  scion_output(p, &(pcb->local_ip), &(pcb->remote_ip), pcb->path, pcb->exts, IP_PROTO_TCP, 0);
 #elif LWIP_NETIF_HWADDRHINT
   ip_output_hinted(p, &pcb->local_ip, &pcb->remote_ip, pcb->ttl, 0, IP_PROTO_TCP,
     &(pcb->addr_hint));
@@ -1496,7 +1496,7 @@ tcp_zero_window_probe(struct tcp_pcb *pcb)
 
   /* Send output to IP */
 #ifdef SCION
-  scion_output(p, &(pcb->local_ip), &(pcb->remote_ip), pcb->path, pcb->exts, IP_PROTO_TCP);
+  scion_output(p, &(pcb->local_ip), &(pcb->remote_ip), pcb->path, pcb->exts, IP_PROTO_TCP, 0);
 #elif LWIP_NETIF_HWADDRHINT
   ip_output_hinted(p, &pcb->local_ip, &pcb->remote_ip, pcb->ttl, 0, IP_PROTO_TCP,
     &(pcb->addr_hint));

--- a/src/include/scion/lwip/ip.h
+++ b/src/include/scion/lwip/ip.h
@@ -81,7 +81,9 @@ extern "C" {
    /* SCION Extensions, TODO(PSz): that should be exts_ctx_t.*/ \
   exts_t *exts; \
   /* SVC Addr */ \
-  u16_t svc;
+  u16_t svc; \
+  /* SCION flags */ \
+  u8_t scion_flags;
 
 struct ip_pcb {
 /* Common members of all PCB types */
@@ -105,6 +107,8 @@ struct ip_pcb {
 /* These flags are inherited (e.g. from a listen-pcb to a connection-pcb): */
 #define SOF_INHERITED   (SOF_REUSEADDR|SOF_KEEPALIVE|SOF_LINGER/*|SOF_DEBUG|SOF_DONTROUTE|SOF_OOBINLINE*/)
 
+#define SCION_ONEHOPPATH 0x01U  /* Connection is using the OneHopPath extension */
+
 
 /** Source SCION address of current_header */
 extern ip_addr_t current_iphdr_src;
@@ -121,7 +125,7 @@ struct netif *ip_route(ip_addr_t *dest);
 err_t scion_input(struct pbuf *p, struct netif *inp);
 #define ip_input scion_input
 err_t scion_output(struct pbuf *p, ip_addr_t *src, ip_addr_t *dest, 
-                   spath_t *path, exts_t *exts, u8_t proto);
+                   spath_t *path, exts_t *exts, u8_t proto, u8_t scion_flags);
 /** Source SCION address of current_header */
 #define ip_current_src_addr()  (&current_iphdr_src)
 /** Destination SCION address of current_header */


### PR DESCRIPTION
This avoids hard-coding any service types, or assumptions about
extensions in use.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-lwip/7)

<!-- Reviewable:end -->
