### PR TITLE
Memory leak fix

### DIFF
--- a/src/core/memp.c
+++ b/src/core/memp.c
@@ -455,16 +455,6 @@ memp_free(memp_t type, void *mem)
 #endif /* MEMP_OVERFLOW_CHECK >= 2 */
 #endif /* MEMP_OVERFLOW_CHECK */
 
-#ifdef SCION
-  if (type == MEMP_TCP_PCB){
-      struct tcp_pcb *pcb = (struct tcp_pcb *)mem;
-      if (pcb->path != NULL){
-          free(pcb->path->raw_path);
-          free(pcb->path);
-      }
-  }
-#endif
-
   MEMP_STATS_DEC(used, type); 
   
   memp->next = memp_tab[type]; 
@@ -477,4 +467,21 @@ memp_free(memp_t type, void *mem)
   SYS_ARCH_UNPROTECT(old_level);
 }
 
+#else /* MEMP_MEM_MALLOC */
+#ifdef SCION
+void
+memp_free_scion(memp_t type, void *mem)
+{
+  /* Free path (if exists) */
+  if (type == MEMP_TCP_PCB){
+      struct tcp_pcb *pcb = (struct tcp_pcb *)mem;
+      if (pcb->path != NULL){
+          mem_free(pcb->path->raw_path);
+          mem_free(pcb->path);
+      }
+  }
+  /* Free the rest */
+  mem_free(mem);
+}
+#endif /* SCION */
 #endif /* MEMP_MEM_MALLOC */

--- a/src/core/memp.c
+++ b/src/core/memp.c
@@ -455,6 +455,16 @@ memp_free(memp_t type, void *mem)
 #endif /* MEMP_OVERFLOW_CHECK >= 2 */
 #endif /* MEMP_OVERFLOW_CHECK */
 
+#ifdef SCION
+  if (type == MEMP_TCP_PCB){
+      struct tcp_pcb *pcb = (struct tcp_pcb *)mem;
+      if (pcb->path != NULL){
+          free(pcb->path->raw_path);
+          free(pcb->path);
+      }
+  }
+#endif
+
   MEMP_STATS_DEC(used, type); 
   
   memp->next = memp_tab[type]; 

--- a/src/core/tcp.c
+++ b/src/core/tcp.c
@@ -1587,12 +1587,6 @@ tcp_pcb_remove(struct tcp_pcb **pcblist, struct tcp_pcb *pcb)
     pcb->flags |= TF_ACK_NOW;
     tcp_output(pcb);
   }
-#ifdef SCION
-  if (pcb->path != NULL){
-      free(pcb->path->raw_path);
-      free(pcb->path);
-  }
-#endif
 
   if (pcb->state != LISTEN) {
     LWIP_ASSERT("unsent segments leaking", pcb->unsent == NULL);

--- a/src/include/lwip/memp.h
+++ b/src/include/lwip/memp.h
@@ -85,7 +85,12 @@ extern const u16_t memp_sizes[MEMP_MAX];
 
 #define memp_init()
 #define memp_malloc(type)     mem_malloc(memp_sizes[type])
+#ifdef SCION
+void  memp_free_scion(memp_t type, void *mem);
+#define memp_free(type, mem)  memp_free_scion(type, mem)
+#else
 #define memp_free(type, mem)  mem_free(mem)
+#endif /* SCION */
 
 #else /* MEMP_MEM_MALLOC */
 


### PR DESCRIPTION
This seems to fix subtle memory leaks when a pcb is killed, but not by calling `tcp_pcb_remove()` (i.e., path associated with the pcb is not freed)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-lwip/8)
<!-- Reviewable:end -->
