### PR TITLE
build_spkt() arguments order fix

### DIFF
--- a/src/core/scion/scion.c
+++ b/src/core/scion/scion.c
@@ -118,9 +118,9 @@ scion_output(struct pbuf *p, ip_addr_t *src, ip_addr_t *dst, spath_t *path,
 
     spkt_t *spkt;
     if (special_exts.count)
-        spkt = build_spkt(src, dst, path, &special_exts, &tcp_data);
+        spkt = build_spkt(dst, src, path, &special_exts, &tcp_data);
     else
-        spkt = build_spkt(src, dst, path, exts, &tcp_data);
+        spkt = build_spkt(dst, src, path, exts, &tcp_data);
     u16_t spkt_len = ntohs(spkt->sch->total_len);
     u8_t packed[spkt_len];
 


### PR DESCRIPTION
This PR syncs `build_spkt()` calls with changes introduced by https://github.com/netsec-ethz/scion/pull/1031

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-lwip/10)
<!-- Reviewable:end -->
