### PR TITLE
Path update

### DIFF
--- a/src/api/api_lib.c
+++ b/src/api/api_lib.c
@@ -783,7 +783,7 @@ netconn_gethostbyname(const char *name, ip_addr_t *addr)
  *
  * @param conn the netconn to update the path
  * @param path the SCION path to be used by the connection
- * @return ERR_OK if bound, any other err_t on failure
+ * @return ERR_ARG for a non-TCP netconn, ERR_OK otherwise
  */
 err_t
 netconn_set_path(struct netconn *conn, spath_t *path)

--- a/src/api/api_lib.c
+++ b/src/api/api_lib.c
@@ -777,4 +777,30 @@ netconn_gethostbyname(const char *name, ip_addr_t *addr)
 }
 #endif /* LWIP_DNS*/
 
+#ifdef SCION
+/**
+ * Sets (updates) the SCION path for the connection.
+ *
+ * @param conn the netconn to update the path
+ * @param path the SCION path to be used by the connection
+ * @return ERR_OK if bound, any other err_t on failure
+ */
+err_t
+netconn_set_path(struct netconn *conn, spath_t *path)
+{
+  struct api_msg msg;
+  err_t err;
+
+  LWIP_ERROR("netconn_set_path: invalid conn", (conn != NULL), return ERR_ARG;);
+
+  msg.function = do_set_path;
+  msg.msg.conn = conn;
+  msg.msg.msg.path = path;
+  err = TCPIP_APIMSG(&msg);
+
+  NETCONN_SET_SAFE_ERR(conn, err);
+  return err;
+}
+#endif /* SCION */
+
 #endif /* LWIP_NETCONN */

--- a/src/api/api_msg.c
+++ b/src/api/api_msg.c
@@ -1562,4 +1562,23 @@ do_gethostbyname(void *arg)
 }
 #endif /* LWIP_DNS */
 
+#ifdef SCION
+/**
+ * Set a SCION path for a TCP connection.
+ *
+ * @param msg the api_msg_msg pointing to the connection.
+ */
+void
+do_set_path(struct api_msg_msg *msg)
+{
+  if ((msg->conn->pcb.tcp != NULL) && (msg->conn->type == NETCONN_TCP)) {
+      scion_copy_path(msg->conn->pcb.ip->path, msg->msg.path);
+      msg->err = ERR_OK;
+  } else {
+      msg->err = ERR_ARG;
+  }
+  TCPIP_APIMSG_ACK(msg);
+}
+#endif /* SCION */
+
 #endif /* LWIP_NETCONN */

--- a/src/core/scion/scion.c
+++ b/src/core/scion/scion.c
@@ -179,3 +179,16 @@ inet_chksum_pseudo_partial(struct pbuf *p,
 {
     return inet_chksum_pseudo(p, src, dest, proto, proto_len);
 }
+
+void scion_copy_path(spath_t *old, const spath_t *new){
+    // Don't allocate if unnecessary
+    // TODO(PSz): could be optimized with spath_t's `buflen`
+    if (old->len < new->len){
+        if (old->raw_path != NULL)
+            free(old->raw_path);
+        old->raw_path = malloc(new->len);
+    }
+    memcpy(old->raw_path, new->raw_path, new->len);
+    old->len = current_path.len;
+    memcpy(&old->first_hop, &new->first_hop, sizeof(HostAddr));
+}

--- a/src/core/scion/scion.c
+++ b/src/core/scion/scion.c
@@ -189,6 +189,6 @@ void scion_copy_path(spath_t *old, const spath_t *new){
         old->raw_path = malloc(new->len);
     }
     memcpy(old->raw_path, new->raw_path, new->len);
-    old->len = current_path.len;
+    old->len = new->len;
     memcpy(&old->first_hop, &new->first_hop, sizeof(HostAddr));
 }

--- a/src/core/scion/scion.c
+++ b/src/core/scion/scion.c
@@ -182,7 +182,6 @@ inet_chksum_pseudo_partial(struct pbuf *p,
 
 void scion_copy_path(spath_t *old, const spath_t *new){
     // Don't allocate if unnecessary
-    // TODO(PSz): could be optimized with spath_t's `buflen`
     if (old->len < new->len){
         if (old->raw_path != NULL)
             free(old->raw_path);

--- a/src/core/tcp_in.c
+++ b/src/core/tcp_in.c
@@ -653,6 +653,8 @@ tcp_process(struct tcp_pcb *pcb)
   err = ERR_OK;
 
 #ifdef SCION
+  /* TODO(PSz): for now the policy is to just use a new path. More sophisticated policies
+   * can be implemented in the future (e.g., only server updates path, etc...). */
   if (pcb->path->len != current_path.len || memcmp(pcb->path->raw_path,
                                                    current_path.raw_path, current_path.len))
       scion_copy_path(pcb->path, &current_path);

--- a/src/core/tcp_in.c
+++ b/src/core/tcp_in.c
@@ -652,6 +652,12 @@ tcp_process(struct tcp_pcb *pcb)
 
   err = ERR_OK;
 
+#ifdef SCION
+  if (pcb->path->len != current_path.len || memcmp(pcb->path->raw_path,
+                                                   current_path.raw_path, current_path.len))
+      scion_copy_path(pcb->path, &current_path);
+#endif
+
   /* Process incoming RST segments. */
   if (flags & TCP_RST) {
     /* First, determine if the reset is acceptable. */

--- a/src/core/tcp_in.c
+++ b/src/core/tcp_in.c
@@ -564,11 +564,10 @@ tcp_listen_input(struct tcp_pcb_listen *pcb)
 
 #ifdef SCION
     spath_t *path = malloc(sizeof *path);
-    path->raw_path = malloc(current_path.len);
-    memcpy(path->raw_path, current_path.raw_path, current_path.len);
-    path->len = current_path.len;
+    path->raw_path = NULL;
+    path->len = 0;
+    scion_copy_path(path, &current_path);
     npcb->path = path;
-    memcpy(&npcb->path->first_hop, &current_path.first_hop, sizeof(HostAddr));
     /* TODO(PSz): it makes sense to put MTU within spath_t. */
 #endif
 

--- a/src/core/tcp_in.c
+++ b/src/core/tcp_in.c
@@ -654,7 +654,7 @@ tcp_process(struct tcp_pcb *pcb)
 
 #ifdef SCION
   /* TODO(PSz): for now the policy is to just use a new path. More sophisticated policies
-   * can be implemented in the future (e.g., only server updates path, etc...). */
+   * can be implemented in the future (e.g., only client updates path, etc...). */
   if (pcb->path->len != current_path.len || memcmp(pcb->path->raw_path,
                                                    current_path.raw_path, current_path.len))
       scion_copy_path(pcb->path, &current_path);

--- a/src/include/lwip/api.h
+++ b/src/include/lwip/api.h
@@ -253,6 +253,11 @@ err_t   netconn_join_leave_group(struct netconn *conn, ip_addr_t *multiaddr,
 err_t   netconn_gethostbyname(const char *name, ip_addr_t *addr);
 #endif /* LWIP_DNS */
 
+#ifdef SCION
+err_t   netconn_set_path(struct netconn *conn, spath_t *path);
+#endif /* SCION */
+
+
 #define netconn_err(conn)               ((conn)->last_err)
 #define netconn_recv_bufsize(conn)      ((conn)->recv_bufsize)
 

--- a/src/include/lwip/api.h
+++ b/src/include/lwip/api.h
@@ -257,7 +257,6 @@ err_t   netconn_gethostbyname(const char *name, ip_addr_t *addr);
 err_t   netconn_set_path(struct netconn *conn, spath_t *path);
 #endif /* SCION */
 
-
 #define netconn_err(conn)               ((conn)->last_err)
 #define netconn_recv_bufsize(conn)      ((conn)->recv_bufsize)
 

--- a/src/include/lwip/api_msg.h
+++ b/src/include/lwip/api_msg.h
@@ -114,6 +114,9 @@ struct api_msg_msg {
       u8_t backlog;
     } lb;
 #endif /* TCP_LISTEN_BACKLOG */
+#ifdef SCION
+    spath_t *path;
+#endif /* SCION */
   } msg;
 };
 
@@ -160,10 +163,14 @@ void do_shutdown        ( struct api_msg_msg *msg);
 #if LWIP_IGMP
 void do_join_leave_group( struct api_msg_msg *msg);
 #endif /* LWIP_IGMP */
+#ifdef SCION
+void do_set_path        ( struct api_msg_msg *msg);
+#endif /* SCION */
 
 #if LWIP_DNS
 void do_gethostbyname(void *arg);
 #endif /* LWIP_DNS */
+
 
 struct netconn* netconn_alloc(enum netconn_type t, netconn_callback callback);
 void netconn_free(struct netconn *conn);

--- a/src/include/lwip/api_msg.h
+++ b/src/include/lwip/api_msg.h
@@ -171,7 +171,6 @@ void do_set_path        ( struct api_msg_msg *msg);
 void do_gethostbyname(void *arg);
 #endif /* LWIP_DNS */
 
-
 struct netconn* netconn_alloc(enum netconn_type t, netconn_callback callback);
 void netconn_free(struct netconn *conn);
 

--- a/src/include/scion/lwip/ip.h
+++ b/src/include/scion/lwip/ip.h
@@ -141,6 +141,7 @@ err_t scion_output(struct pbuf *p, ip_addr_t *src, ip_addr_t *dest,
 /** Pointer to the output function. Set by the dispatcher. */
 int (*tcp_scion_output)(uint8_t *, int, HostAddr *);
 
+void scion_copy_path(spath_t *old, const spath_t *new);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- add a new netconn call for path update
- receiver of a packet updates its cached path if it is different from the packet's path. (We may want to change this policy in the future.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/netsec-ethz/scion-lwip/13)
<!-- Reviewable:end -->
